### PR TITLE
adding retry parameter to URLchecker, will double time between retrie…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,22 @@ jobs:
         file_types: .md,.py,.rst
 
         # Choose whether to include file with no URLs in the prints.
-        print_all: False
+        print_all: false
+
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 5
+
+        # How many times to retry a failed request (each is logged, defaults to 1)
+        retry_count: 3
 
         # A comma separated links to exclude during URL checks
-        white_listed_urls: https://superkogito.github.io/figures/fig2.html, https://superkogito.github.io/figures/fig4.html
+        white_listed_urls: https://superkogito.github.io/figures/fig2.html,https://superkogito.github.io/figures/fig4.html
 
         # A comma separated patterns to exclude during URL checks
         white_listed_patterns: https://superkogito.github.io/tables
         
         # choose if the force pass or not 
-        force_pass = True
+        force_pass = true
 ```
 ## Inputs
 
@@ -50,9 +56,11 @@ jobs:
 | `git_path`                 | <span style="color:red"> required </span>    | The path to the start directory of the project.                  |
 | `file_types`               | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
 | `print_all`                | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
+| `retry_count`              | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |
+| `timeout`                  | <span style="color:green"> optional </span>  | The timeout to provide to requests to wait for a response.       |
 | `white_listed_urls`        | <span style="color:green"> optional </span>  | A comma separated links to exclude during URL checks.            |
 | `white_listed_patterns`    | <span style="color:green"> optional </span>  | A comma separated patterns to exclude during URL checks.         |
-| `force_pass`               | <span style="color:green"> optional </span>  | Choose whether to force a pass when checks are done.               |
+| `force_pass`               | <span style="color:green"> optional </span>  | Choose whether to force a pass when checks are done.             |
 
 ## Demo
 

--- a/action.yml
+++ b/action.yml
@@ -5,27 +5,37 @@ description: "Automatically check for broken links in a project files. This incl
 inputs:
   git_path:
     description: "The project base path."
-    required: True
+    required: true
 
   file_types:
     description: "A comma-separated list of file types to cover in the URL checks"
-    required: False
+    required: false
     default: ".md,.py,.rst,.html"
 
   print_all:
     description: "Choose whether to include file with no URLs in the prints."
-    required: False
-    default: False
+    required: false
+    default: false
+
+  retry_count:
+    description: "If a request fails, retry this number of times. Defaults to 1"
+    required: false
+    default: 1
+
+  timeout:
+    description: "The timeout (seconds) to provide to requests to wait for a response."
+    required: false
+    default: 5
 
   white_listed_urls:
     description: "A comma seperated links to exclude during URL checks."
-    required: False
-    default: False
+    required: false
+    default: false
 
   white_listed_patterns:
     description: "A comma seperated patterns to exclude during URL checks."
-    required: False
-    default: False
+    required: false
+    default: false
 
 runs:
   using: "docker"

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -2,35 +2,67 @@
 # -*- coding: utf-8 -*-
 import os
 import requests
+import time
 from core import urlmarker
 
 
-def check_response_status_code(url, response, print_format, check_results):
+def record_response(url, response, check_results):
     """
-    check and print response status of an input url.
+    check and print response status of an input url. Returns a boolean
+    to indicate if retry is needed.
 
     Args:
         url          (str) : url text.
         response    (list) : request response from the url request.
         print_format (str) : format to print the logs according to.
     """
+    # response of None indicates a failure
+    if not response:
+        check_results[1].append(url)
+
+    # success
     if response.status_code == 200:
-        print(print_format % (url, "\x1b[31m" + "." + "\x1b[0m"))
         check_results[0].append(url)
+
+    # Any other error
     else:
-        print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
         check_results[1].append(url)
 
 
-def check_urls(file, urls):
+def check_response_status_code(url, response, print_format):
+    """
+    check response status of an input url. Returns a boolean
+    to indicate if retry is needed.
+
+    Args:
+        url          (str) : url text.
+        response    (list) : request response from the url request.
+    """
+    # Case 1: response is None indicating triggered error
+    if not response:
+        print(print_format % (url, "\x1b[31m" + "." + "\x1b[0m"))
+        return False
+
+    # Case 2: succcess!
+    if response.status_code == 200:
+        print(print_format % (url, "\x1b[31m" + "." + "\x1b[0m"))
+        return False
+
+    # Case 3: failure of some kind
+    print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
+    return True
+
+
+def check_urls(file, urls, retry_count=1, timeout=5):
     """
     check urls extracted from a certain file and print the checks results.
 
     Args:
         file  (str) : path to file.
         urls (list) : list of urls to check.
+        retry_count (int): a number of retries to issue (defaults to 1, no retry)
     """
-    # init results list
+    # init results list (first is success, second is issue)
     check_results = [[], []]
 
     # get longest url size
@@ -39,21 +71,39 @@ def check_urls(file, urls):
     # define orint format
     print_format = "%" + long_url + "s %10s"
 
-    # chech links
+    # we will double the time for retry each time
+    retry_seconds = 2
+    do_retry = True
+
+    # check links
     for url in [url for url in urls if "http" in url]:
         url_termination = "." + os.path.basename(url).split(".")[-1]
 
-        try:
-            response = requests.get(url, stream=True, allow_redirects=True, timeout=5)
-            check_response_status_code(url, response, print_format, check_results)
+        while retry_count > 0 and do_retry:
+            response = None            
+            try:
+                response = requests.get(url, stream=True, allow_redirects=True, timeout=timeout)
 
-        except requests.exceptions.Timeout as e:
-            print(e)
+            except requests.exceptions.Timeout as e:
+                print(e)
 
-        except requests.exceptions.ConnectionError:
-            print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
+            except requests.exceptions.ConnectionError:
+                print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
 
-        except Exception as e:
-            print(e.message)
+            except Exception as e:
+                print(e.message)
+ 
+            retry_count-=1
 
-        return check_results
+            # Break from the loop if we have success, update user
+            do_retry = check_response_status_code(response, print_format)
+
+            # If we try again, pause for retry seconds and update retry seconds
+            if do_retry:
+                time.sleep(retry_seconds)
+                retry_seconds = retry_seconds * 2
+  
+        # When we break from while, we record final response
+        record_response(url, response, check_results)
+
+    return check_results


### PR DESCRIPTION
This pull request will attempt to address #15 by adding a retry parameter to the action. Specifically:

 - the retry_count determines the number of retries to do. Each retry starts at 2 seconds, and then is doubled as we advance (2, 4, 8, 16, etc.)
 - I think #16 is a bug so I moved it out in the loop, let me know if this is intentional or I'm missing something!
 - I exposed the timeout to requests to the user, with the default being what it already was set to (5 seconds)
 - I changed the booleans in the action.yml to be all lowercase, mostly for aesthetics because it renders a different color in the editor and it's easier to see the booleans. To allow for either lower or uppcase set by a user, the envar for each is parsed and then made lowercase with .lower().
 
Currently, we print and add to the list of check_results each retry attempt, the idea being that a retry could have different results. I'm thinking we might want to refactor this so that the failed url is only added _after_ it's failed all retries - that way we don't have the same url in a failed / success list if it worked on retry.

I held off on further implementation because I think @SuperKogito you had a specific idea for error checking that I wanted to ask for more detail about. Take a look here, and let me know what we should do next!

Signed-off-by: vsoch <vsochat@stanford.edu>