### PR TITLE
Fixing bug with retry, and tweaks to interface

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,12 @@ inputs:
   white_listed_urls:
     description: "A comma seperated links to exclude during URL checks."
     required: false
-    default: false
+    default: ""
 
   white_listed_patterns:
     description: "A comma seperated patterns to exclude during URL checks."
     required: false
-    default: false
+    default: ""
 
 runs:
   using: "docker"

--- a/check.py
+++ b/check.py
@@ -108,8 +108,9 @@ if __name__ == "__main__":
 
     # exit
     if (force_pass == "false") and (len(check_results[1]) > 0) :
-        print("Done.")
+        print("Done. The following URLS did not pass:")
+        print("\n".join(check_results[1]))
         exit(False)
     else :
-        print("Done.")
+        print("Done. All URLS passed.")
         exit(True)

--- a/check.py
+++ b/check.py
@@ -94,6 +94,10 @@ if __name__ == "__main__":
     retry_count = int(os.getenv("INPUT_RETRY_COUNT", 1))
     timeout = int(os.getenv("INPUT_TIMEOUT", 5)) # seconds
 
+    # Are whitelisted urls provided, or an empty string?
+    white_listed_urls = [x for x in white_listed_urls if x not in ["", None]]
+    white_listed_patterns = [x for x in white_listed_patterns if x not in ["", None]]
+
     # Alert user about settings
     print("   git path: %s" % git_path)
     print(" file types: %s" % file_types)

--- a/check.py
+++ b/check.py
@@ -52,6 +52,8 @@ def check_repo(file_paths, print_all, white_listed_urls, white_listed_patterns, 
     """
     check all urls extracted from all files in a repository.
     """
+    check_results = []
+
     # loop files
     for file in file_paths:
 
@@ -75,6 +77,8 @@ def check_repo(file_paths, print_all, white_listed_urls, white_listed_patterns, 
             if print_all == "true":
                 print("\n", file, "\n", "-" * len(file))
                 print("No urls found.")
+
+    return check_results
 
 
 if __name__ == "__main__":

--- a/check.py
+++ b/check.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import subprocess
+import sys
 from core import urlproc
 from core import fileproc
 
@@ -93,6 +94,16 @@ if __name__ == "__main__":
     retry_count = int(os.getenv("INPUT_RETRY_COUNT", 1))
     timeout = int(os.getenv("INPUT_TIMEOUT", 5)) # seconds
 
+    # Alert user about settings
+    print("   git path: %s" % git_path)
+    print(" file types: %s" % file_types)
+    print("  print all: %s" % print_all)
+    print("  whistlist: %s" % white_listed_urls)
+    print("   patterns: %s" % white_listed_patterns)
+    print(" force pass: %s" % force_pass)
+    print("retry count: %s" % retry_count)
+    print("    timeout: %s" % timeout)
+
     # clone project repo
     base_path = clone_repo(git_path)
 
@@ -110,7 +121,7 @@ if __name__ == "__main__":
     if (force_pass == "false") and (len(check_results[1]) > 0) :
         print("Done. The following URLS did not pass:")
         print("\n".join(check_results[1]))
-        exit(False)
+        sys.exit(1)
     else :
         print("Done. All URLS passed.")
-        exit(True)
+        sys.exit(0)

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -40,16 +40,16 @@ def check_response_status_code(url, response):
     """
     # Case 1: response is None indicating triggered error
     if not response:
-        print("\x1b[32m" + url + "\x1b[0m")
+        print("\x1b[31m" + url + "\x1b[0m")
         return False
 
     # Case 2: succcess!
     if response.status_code == 200:
-        print("\x1b[31m" + url + "\x1b[0m")
+        print("\x1b[32m" + url + "\x1b[0m")
         return False
 
     # Case 3: failure of some kind
-    print("\x1b[32m" + url + "\x1b[0m")
+    print("\x1b[31m" + url + "\x1b[0m")
     return True
 
 
@@ -89,7 +89,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
                 print(e)
 
             except requests.exceptions.ConnectionError:
-                print("\x1b[32m" + url + "\x1b[0m")
+                print("\x1b[31m" + url + "\x1b[0m")
 
             except Exception as e:
                 print(e.message)

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -64,6 +64,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
     """
     # init results list (first is success, second is issue)
     check_results = [[], []]
+    seen = set()
 
     # we will double the time for retry each time
     retry_seconds = 2
@@ -72,6 +73,12 @@ def check_urls(file, urls, retry_count=1, timeout=5):
     # check links
     for url in [url for url in urls if "http" in url]:
         url_termination = "." + os.path.basename(url).split(".")[-1]
+
+        # No need to test the same URL twice
+        if url in seen:
+            continue
+
+        seen.add(url)
 
         while retry_count > 0 and do_retry:
             response = None            

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -96,7 +96,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
             retry_count-=1
 
             # Break from the loop if we have success, update user
-            do_retry = check_response_status_code(response, print_format)
+            do_retry = check_response_status_code(url, response, print_format)
 
             # If we try again, pause for retry seconds and update retry seconds
             if do_retry:

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -14,7 +14,7 @@ def record_response(url, response, check_results):
     Args:
         url          (str) : url text.
         response    (list) : request response from the url request.
-        print_format (str) : format to print the logs according to.
+        check_results (list) : list of lists, success appended to 0, failure to 1.
     """
     # response of None indicates a failure
     if not response:
@@ -29,7 +29,7 @@ def record_response(url, response, check_results):
         check_results[1].append(url)
 
 
-def check_response_status_code(url, response, print_format):
+def check_response_status_code(url, response):
     """
     check response status of an input url. Returns a boolean
     to indicate if retry is needed.
@@ -40,16 +40,16 @@ def check_response_status_code(url, response, print_format):
     """
     # Case 1: response is None indicating triggered error
     if not response:
-        print(print_format % (url, "\x1b[31m" + "." + "\x1b[0m"))
+        print("\x1b[32m" + url + "\x1b[0m")
         return False
 
     # Case 2: succcess!
     if response.status_code == 200:
-        print(print_format % (url, "\x1b[31m" + "." + "\x1b[0m"))
+        print("\x1b[31m" + url + "\x1b[0m")
         return False
 
     # Case 3: failure of some kind
-    print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
+    print("\x1b[32m" + url + "\x1b[0m")
     return True
 
 
@@ -65,12 +65,6 @@ def check_urls(file, urls, retry_count=1, timeout=5):
     # init results list (first is success, second is issue)
     check_results = [[], []]
 
-    # get longest url size
-    long_url = str(max([len(url) for url in urls]))
-
-    # define orint format
-    print_format = "%" + long_url + "s %10s"
-
     # we will double the time for retry each time
     retry_seconds = 2
     do_retry = True
@@ -82,13 +76,13 @@ def check_urls(file, urls, retry_count=1, timeout=5):
         while retry_count > 0 and do_retry:
             response = None            
             try:
-                response = requests.get(url, stream=True, allow_redirects=True, timeout=timeout)
+                response = requests.get(url, timeout=timeout)
 
             except requests.exceptions.Timeout as e:
                 print(e)
 
             except requests.exceptions.ConnectionError:
-                print(print_format % (url, "\x1b[32m" +"x" + "\x1b[0m"))
+                print("\x1b[32m" + url + "\x1b[0m")
 
             except Exception as e:
                 print(e.message)
@@ -96,7 +90,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
             retry_count-=1
 
             # Break from the loop if we have success, update user
-            do_retry = check_response_status_code(url, response, print_format)
+            do_retry = check_response_status_code(url, response)
 
             # If we try again, pause for retry seconds and update retry seconds
             if do_retry:

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -21,7 +21,7 @@ def record_response(url, response, check_results):
         check_results[1].append(url)
 
     # success
-    if response.status_code == 200:
+    elif response.status_code == 200:
         check_results[0].append(url)
 
     # Any other error
@@ -100,6 +100,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
 
             # If we try again, pause for retry seconds and update retry seconds
             if do_retry:
+                print("Retry %s for %s" %(retry_count, url))
                 time.sleep(retry_seconds)
                 retry_seconds = retry_seconds * 2
   


### PR DESCRIPTION
This PR will address #18, specifically there was a bug in a missing parameter. However, I wound up doing several changes that I think overall improve the usage of the urlchecker greatly! I'll discuss them here.

- default of false was a bug for whitelist parameters -the default needed to be an empty string, and then in the case of a list with an empty string `[""]` that would be parsed with split, we need to ensure that we remove it.
 - I'm not a heavy user of exit() but it was having weird functionality where the success loop would exit with an error code, and the error loop the other way around. I changed this to a clean sys.exit with an error code (0 for success, 1 for fail) so it's clear.
 - the check_repos function wasn't returning the list like it should - not sure how it was working before!
 - I added a clear printing of all params to the onset of the function so it's easier to debug when a user hits an issue (they can copy paste those lines so you can quickly debug)
 - I added a check so that we don't check the same urls twice for any given page.
 - I removed stream=True from requests.get. This is typically used for streaming large files to disk, and for checking urls in documentation it's more likely to lead to some error because it tries to hold on to the connection.
 - I also removed the param to follow redirects, as following redirects is the default for requests.
 - I was having a really hard time looking at how the results were printed - the spacing was a little strange. I found that when I removed the formatting and colored the entire URL, the interface is much more clear to visually parse! Here is the UI before the change:

![Screenshot_2020-03-10 testing urlchecker that has retry by vsoch · Pull Request #211 · HPC-buildtest buildtest-framework](https://user-images.githubusercontent.com/814322/76347136-b7d08280-62cb-11ea-9817-cd0505fc3948.png)

and after

![Screenshot_2020-03-10 testing urlchecker that has retry by vsoch · Pull Request #211 · HPC-buildtest buildtest-framework(2)](https://user-images.githubusercontent.com/814322/76347151-bef79080-62cb-11ea-9b87-8e26ec5090d7.png)

Notice how I can quickly see green (passing) and the parameters I've set at the top. I hope you like this better, I like it a lot better! It also simplifies the functions a lot by not needing to pass around a format string.

You can see the full successful run (with new syntax) here:

https://github.com/HPC-buildtest/buildtest-framework/pull/211/checks?check_run_id=498679759