### PR TITLE
Add/checkout optional git path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ jobs:
     - name: URLs-checker
       uses: urlstechie/URLs-checker@0.1.5
       with:
+        # A subfolder or path to navigate to in the present or cloned repository
+        subfolder: docs
+
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.rst
 
@@ -80,6 +83,9 @@ jobs:
         # If a git_path is defined to clone, clone this branch (defaults to master)
         branch: devel
 
+        # A subfolder or path to navigate to in the present or cloned repository
+        subfolder: docs
+
         # Delete the cloned repository after running URLchecked (default is false)
         cleanup: true
 
@@ -112,6 +118,7 @@ jobs:
 | `git_path`                 | <span style="color:green"> optional </span>  | A git url to clone, if the repository isn't already in $PWD      |
 | `branch`                   | <span style="color:green"> optional </span>  | If we do a clone, clone this branch (defaults to master          |
 | `cleanup`                  | <span style="color:green"> optional </span>  | If we do a clone, delete the cloned folder after (false)         |
+| `subfolder`                | <span style="color:green"> optional </span>  | A subfolder to navigate to in the repository to check            |
 | `file_types`               | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
 | `print_all`                | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
 | `retry_count`              | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,56 @@ A GitHub action to collect and check URLs in a project (code and documentation).
 The action aims at detecting and reporting broken links.
 
 # How to use?
-## Example
+
+## Example with Checkout
+
+For most use cases, you will want to use the git repository that is being checked
+for a GitHub actions, and we do this by way of the [actions/checkout](https://github.com/actions/checkout) action.
+
+```
+name: Check URLs
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: URLs-checker
+      uses: urlstechie/URLs-checker@0.1.5
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.py,.rst
+
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 5
+
+        # How many times to retry a failed request (each is logged, defaults to 1)
+        retry_count: 3
+
+        # A comma separated links to exclude during URL checks
+        white_listed_urls: https://github.com/SuperKogito/URLs-checker/issues/1,https://github.com/SuperKogito/URLs-checker/issues/2
+
+        # A comma separated patterns to exclude during URL checks
+        white_listed_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
+
+        # choose if the force pass or not
+        force_pass = true
+```
+
+
+## Example with Custom Clone
+
+It could, however, be the case that you've set up a repository with one or more uses of the URLChecker
+that must clone one or more repos (possibly with varying branches) before doing the check.
+In this case, you might want to define `git_path` and `branch` for each section.
+An example is below:
+
 ```
 name: Check URLs
 
@@ -23,10 +72,16 @@ jobs:
 
     steps:
     - name: URLs-checker
-      uses: SuperKogito/URLs-checker@0.1.5
+      uses: urlstechie/URLs-checker@0.1.5
       with:
-        # The project base path.
+        # A project to clone. If not provided, assumes already cloned in the present working directory.
         git_path: https://github.com/urlstechie/URLs-checker-test-repo
+
+        # If a git_path is defined to clone, clone this branch (defaults to master)
+        branch: devel
+
+        # Delete the cloned repository after running URLchecked (default is false)
+        cleanup: true
 
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.rst
@@ -43,19 +98,20 @@ jobs:
         # A comma separated links to exclude during URL checks
         white_listed_urls: https://github.com/SuperKogito/URLs-checker/issues/1,https://github.com/SuperKogito/URLs-checker/issues/2
 
-
         # A comma separated patterns to exclude during URL checks
         white_listed_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
-
 
         # choose if the force pass or not
         force_pass = true
 ```
 ## Inputs
 
+
 | variable name              | variable type                                |      variable description                                        |
 |----------------------------|----------------------------------------------|------------------------------------------------------------------|
-| `git_path`                 | <span style="color:red"> required </span>    | The path to the start directory of the project.                  |
+| `git_path`                 | <span style="color:green"> optional </span>  | A git url to clone, if the repository isn't already in $PWD      |
+| `branch`                   | <span style="color:green"> optional </span>  | If we do a clone, clone this branch (defaults to master          |
+| `cleanup`                  | <span style="color:green"> optional </span>  | If we do a clone, delete the cloned folder after (false)         |
 | `file_types`               | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
 | `print_all`                | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
 | `retry_count`              | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,18 @@ description: "Automatically check for broken links in a project files. This incl
 
 inputs:
   git_path:
-    description: "The project base path."
-    required: true
+    description: "A project to clone. If not provided, assumes already cloned in the present working directory."
+    required: false
+
+  branch:
+    description: "If a project (git_path) is defined, use this branch. Defaults to master"
+    required: false
+    default: master
+
+  cleanup:
+    description: "Cleanup (delete) repository to check after doing so (appropriate for when clone is done)"
+    required: false
+    default: false
 
   file_types:
     description: "A comma-separated list of file types to cover in the URL checks"

--- a/check.py
+++ b/check.py
@@ -7,13 +7,13 @@ from core import urlproc
 from core import fileproc
 
 
-def clone_repo(git_path):
+def clone_repo(git_path, branch="master"):
     """
     clone and name a git repository.
     """
     base_path = os.path.basename(git_path)
     # clone repo
-    _ = subprocess.run(["git", "clone", git_path, base_path],
+    _ = subprocess.run(["git", "clone", "-b", branch, git_path, base_path],
                        stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE)
     return base_path
@@ -27,7 +27,6 @@ def del_repo(base_path):
     _ = subprocess.run(["rm", "-R", "-f", base_path],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE)
-    return True
 
 
 def white_listed(url, white_listed_urls, white_listed_patterns):
@@ -86,6 +85,8 @@ if __name__ == "__main__":
 
     # read input variables
     git_path = os.getenv("INPUT_GIT_PATH", "")
+    branch = os.getenv("INPUT_BRANCH", "master")   
+    cleanup = os.getenv("INPUT_CLEANUP", "false").lower()   
     file_types = os.getenv("INPUT_FILE_TYPES", "").split(",")
     print_all = os.getenv("INPUT_PRINT_ALL", "").lower()
     white_listed_urls = os.getenv("INPUT_WHITE_LISTED_URLS", "").split(",")
@@ -98,8 +99,14 @@ if __name__ == "__main__":
     white_listed_urls = [x for x in white_listed_urls if x not in ["", None]]
     white_listed_patterns = [x for x in white_listed_patterns if x not in ["", None]]
 
+    # clone project repo if defined
+    base_path = os.environ.get("GITHUB_WORKSPACE", os.getcwd())
+
     # Alert user about settings
+    print("  base path: %s" % base_path)
     print("   git path: %s" % git_path)
+    print("     branch: %s" % branch)
+    print("    cleanup: %s" % cleanup)
     print(" file types: %s" % file_types)
     print("  print all: %s" % print_all)
     print("  whistlist: %s" % white_listed_urls)
@@ -108,8 +115,13 @@ if __name__ == "__main__":
     print("retry count: %s" % retry_count)
     print("    timeout: %s" % timeout)
 
-    # clone project repo
-    base_path = clone_repo(git_path)
+    # If a custom base path is provided, clone and use it
+    if git_path not in ["", None]:
+        base_path = clone_repo(git_path, branch)
+
+    # Assert that the base path exists
+    if not os.path.exists(base_path):
+        sys.exit("Cannot find %s to check" % base_path)
 
     # get all file paths
     file_paths = fileproc.get_file_paths(base_path, file_types)
@@ -118,15 +130,16 @@ if __name__ == "__main__":
     check_results = check_repo(file_paths, print_all, white_listed_urls,
                                white_listed_patterns, retry_count, timeout)
 
-    # delete repo when done
-    deletion_status = del_repo(base_path)
+    # delete repo when done, if requested
+    if cleanup == "true":
+        del_repo(base_path)
 
     # exit
-    if (force_pass == "false") and (len(check_results[1]) > 0) :
+    if force_pass == "false" and len(check_results[1]) > 0 :
         print("Done. The following URLS did not pass:")
         print("\x1b[31m" + "\n".join(check_results[1]) + "\x1b[0m")
         sys.exit(1)
 
-    else :
+    else:
         print("Done. All URLS passed.")
         sys.exit(0)

--- a/core/fileproc.py
+++ b/core/fileproc.py
@@ -65,5 +65,5 @@ def collect_links_from_file(file_path):
 
     # get and filter urls
     urls = re.findall(urlmarker.URL_REGEX, content)
-    urls = [url for url in urls if "http" in url]
+    urls = [url.strip() for url in urls if "http" in url]
     return urls

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import os
+import random
 import requests
 import time
 from core import urlmarker
@@ -54,6 +55,37 @@ def check_response_status_code(url, response):
     return True
 
 
+def get_user_agent():
+    """Return a randomly chosen user agent for requests
+    """
+    agents = [
+        ('Mozilla/5.0 (X11; Linux x86_64) '
+         'AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/57.0.2987.110 '
+         'Safari/537.36'),  # chrome
+        ('Mozilla/5.0 (X11; Linux x86_64) '
+         'AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/61.0.3163.79 '
+         'Safari/537.36'),  # chrome
+        ('Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:55.0) '
+         'Gecko/20100101 '
+         'Firefox/55.0'),  # firefox
+        ('Mozilla/5.0 (X11; Linux x86_64) '
+         'AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/61.0.3163.91 '
+         'Safari/537.36'),  # chrome
+        ('Mozilla/5.0 (X11; Linux x86_64) '
+         'AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/62.0.3202.89 '
+         'Safari/537.36'),  # chrome
+        ('Mozilla/5.0 (X11; Linux x86_64) '
+         'AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/63.0.3239.108 '
+         'Safari/537.36'),  # chrome
+    ]
+    return random.choice(agents)
+
+
 def check_urls(file, urls, retry_count=1, timeout=5):
     """
     check urls extracted from a certain file and print the checks results.
@@ -69,6 +101,10 @@ def check_urls(file, urls, retry_count=1, timeout=5):
 
     # we will double the time for retry each time
     retry_seconds = 2
+
+    # Some sites will return 403 if it's not a "human" user agent
+    user_agent = get_user_agent()
+    headers = {'User-Agent': user_agent}
 
     # check links
     for url in [url for url in urls if "http" in url]:
@@ -91,7 +127,7 @@ def check_urls(file, urls, retry_count=1, timeout=5):
         while rcount > 0 and do_retry:
             response = None
             try:
-                response = requests.get(url, timeout=pause)
+                response = requests.get(url, timeout=pause, headers=headers)
 
             except requests.exceptions.Timeout as e:
                 print(e)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -19,7 +19,8 @@ def test_clone_and_del_repo(git_path):
     assert(base_path == os.path.basename(git_path))
 
     # delete should have return code of 0 (success)
-    assert del_repo(base_path) == 0
+    if not del_repo(base_path) == 0:
+        raise AssertionError
 
 
 @pytest.mark.parametrize('file_paths', [["tests/test_files/sample_test_file.md"],

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -17,10 +17,9 @@ def test_clone_and_del_repo(git_path):
     # clone
     base_path = clone_repo(git_path)
     assert(base_path == os.path.basename(git_path))
-    # delete
-    deletion_status = del_repo(base_path)
-    if not(deletion_status): 
-        raise AssertionError
+
+    # delete should have return code of 0 (success)
+    assert del_repo(base_path) == 0
 
 
 @pytest.mark.parametrize('file_paths', [["tests/test_files/sample_test_file.md"],


### PR DESCRIPTION
This pull request will allow for easier usage of the url checker on GitHub actions, meaning that the git_path is optional, and if not provided, we use the checkout of the branch that is already done by default. Specifically:

 - git_path is now optional. If not provided, it defaults to using the environment variable GITHUB_WORKFLOW where the repository is cloned, and if that isn't found, it defaults to the present working directory.
 - branch is an added variable in the case that a user _does_ want to clone, the branch can be specified. This defaults to master.
 - cleanup is an added argument, which is needed now that we are interacting with the checked out repository directly. Most users won't want this deleted, so the default is false.
 - I also added a `subfolder` argument, the reason being that after clone of a git path (or use of the already checked out repository) we might want to limit checks to a particular folder. In my testing case, I only wanted to parse files in docs/
 - I noticed that several URLs in my testing returned 403, and this was because of the user agent string. I added a function to randomly choose a more human like user agent, and these 403s turned to 200.
 - I also updated the del_repo and _clone_repo functions to use the return code. The del_repo was previously returning a boolean regardless of status, which doesn't tell us much.
 - the README.md is updated for input arguments, and also with usage examples for both cases (with and without git_path).
 - Finally, I added an extra strip to clean up urls in the case that there is a trailing newline.

You can see the branch in action here: https://github.com/HPC-buildtest/buildtest-framework/pull/211/checks?check_run_id=501529549 