### PR TITLE
Adding files and file patterns to skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,25 +107,29 @@ jobs:
         # A comma separated patterns to exclude during URL checks
         white_listed_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
 
+        # A comma separated list of file patterns (direct paths work as well) to exclude
+        white_listed_files: README.md,/github/workspace/_config.yml
+
         # choose if the force pass or not
         force_pass = true
 ```
 ## Inputs
 
 
-| variable name              | variable type                                |      variable description                                        |
-|----------------------------|----------------------------------------------|------------------------------------------------------------------|
-| `git_path`                 | <span style="color:green"> optional </span>  | A git url to clone, if the repository isn't already in $PWD      |
-| `branch`                   | <span style="color:green"> optional </span>  | If we do a clone, clone this branch (defaults to master          |
-| `cleanup`                  | <span style="color:green"> optional </span>  | If we do a clone, delete the cloned folder after (false)         |
-| `subfolder`                | <span style="color:green"> optional </span>  | A subfolder to navigate to in the repository to check            |
-| `file_types`               | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
-| `print_all`                | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
-| `retry_count`              | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |
-| `timeout`                  | <span style="color:green"> optional </span>  | The timeout to provide to requests to wait for a response.       |
-| `white_listed_urls`        | <span style="color:green"> optional </span>  | A comma separated links to exclude during URL checks.            |
-| `white_listed_patterns`    | <span style="color:green"> optional </span>  | A comma separated patterns to exclude during URL checks.         |
-| `force_pass`               | <span style="color:green"> optional </span>  | Choose whether to force a pass when checks are done.             |
+| variable name               | variable type                                |      variable description                                        |
+|-----------------------------|----------------------------------------------|------------------------------------------------------------------|
+| `git_path`                  | <span style="color:green"> optional </span>  | A git url to clone, if the repository isn't already in $PWD      |
+| `branch`                    | <span style="color:green"> optional </span>  | If we do a clone, clone this branch (defaults to master          |
+| `cleanup`                   | <span style="color:green"> optional </span>  | If we do a clone, delete the cloned folder after (false)         |
+| `subfolder`                 | <span style="color:green"> optional </span>  | A subfolder to navigate to in the repository to check            |
+| `file_types`                | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
+| `print_all`                 | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
+| `retry_count`               | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |
+| `timeout`                   | <span style="color:green"> optional </span>  | The timeout to provide to requests to wait for a response.       |
+| `white_listed_urls`         | <span style="color:green"> optional </span>  | A comma separated links to exclude during URL checks.            |
+| `white_listed_patterns`     | <span style="color:green"> optional </span>  | A comma separated patterns to exclude during URL checks.         |
+| `white_listed_files`        | <span style="color:green"> optional </span>  | Full paths to files to exclude (comma separated list).           |
+| `force_pass`                | <span style="color:green"> optional </span>  | Choose whether to force a pass when checks are done.             |
 
 ## Demo
 - Using version > 0.1.4

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,11 @@ inputs:
     required: false
     default: ""
 
+  white_listed_files:
+    description: "A comma seperated list of paths or patterns to exclude during URL checks."
+    required: false
+    default: ""
+
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/check.py
+++ b/check.py
@@ -52,7 +52,12 @@ def white_listed(url, white_listed_urls, white_listed_patterns):
     return False
 
 
-def check_repo(file_paths, print_all, white_listed_urls, white_listed_patterns, retry_count=1, timeout=5):
+def check_repo(file_paths,
+               print_all,
+               white_listed_urls,
+               white_listed_patterns,
+               retry_count=1,
+               timeout=5):
     """
     check all urls extracted from all files in a repository.
     """
@@ -62,11 +67,11 @@ def check_repo(file_paths, print_all, white_listed_urls, white_listed_patterns, 
     # loop files
     for file in file_paths:
 
-        # collect links from each file
+        # collect links from each file (unique=True is set)
         urls = fileproc.collect_links_from_file(file)
 
         # eliminate white listed urls and white listed white listed patterns
-        if len(white_listed_urls) > 0 or len(white_listed_patterns) > 0:
+        if white_listed_urls or white_listed_patterns:
             urls = [url for url in urls
                     if not white_listed(url,
                                         white_listed_urls,
@@ -87,10 +92,14 @@ def check_repo(file_paths, print_all, white_listed_urls, white_listed_patterns, 
 
 
 def get_branch():
-    """Derive the selected branch. We first look to the environment variable
-       for INPUT_BRANCH, meaning that the user set the branch variable. If
-       that is unset we parse GITHUB_REF. If both of those are unset,
-       then we default to master.
+    """
+    Derive the selected branch. We first look to the environment variable
+    for INPUT_BRANCH, meaning that the user set the branch variable. If
+    that is unset we parse GITHUB_REF. If both of those are unset,
+    then we default to master.
+
+    Returns:
+        the branch found in the environment, otherwise master.
     """
     # First check goes to use setting in action
     branch = os.getenv("INPUT_BRANCH")
@@ -114,33 +123,30 @@ if __name__ == "__main__":
     cleanup = os.getenv("INPUT_CLEANUP", "false").lower()
     file_types = os.getenv("INPUT_FILE_TYPES", "").split(",")
     print_all = os.getenv("INPUT_PRINT_ALL", "").lower()
-    white_listed_urls = os.getenv("INPUT_WHITE_LISTED_URLS", "").split(",")
-    white_listed_patterns = os.getenv("INPUT_WHITE_LISTED_PATTERNS", "").split(",")
+    white_listed_urls = urlproc.remove_empty(os.getenv("INPUT_WHITE_LISTED_URLS", "").split(","))
+    white_listed_patterns = urlproc.remove_empty(os.getenv("INPUT_WHITE_LISTED_PATTERNS", "").split(","))
+    white_listed_files = urlproc.remove_empty(os.getenv("INPUT_WHITE_LISTED_FILES", "").split(","))
     force_pass = os.getenv("INPUT_FORCE_PASS", "false").lower()
     retry_count = int(os.getenv("INPUT_RETRY_COUNT", 1))
     timeout = int(os.getenv("INPUT_TIMEOUT", 5)) # seconds
-
-    # Are whitelisted urls provided, or an empty string?
-    white_listed_urls = [x for x in white_listed_urls if x not in ["", None]]
-    white_listed_patterns = [x for x in white_listed_patterns if x not in ["", None]]
 
     # clone project repo if defined
     base_path = os.environ.get("GITHUB_WORKSPACE", os.getcwd())
 
     # Alert user about settings
-    print("  base path: %s" % base_path)
-    print("   git path: %s" % git_path)
-    print("  subfolder: %s" % subfolder)
-    print("     branch: %s" % branch)
-    print("    cleanup: %s" % cleanup)
-    print(" file types: %s" % file_types)
-    print("  print all: %s" % print_all)
-    print("  whistlist: %s" % white_listed_urls)
-    print("   patterns: %s" % white_listed_patterns)
-    print(" force pass: %s" % force_pass)
-    print("retry count: %s" % retry_count)
-    print("    timeout: %s" % timeout)
-
+    print("      base path: %s" % base_path)
+    print("       git path: %s" % git_path)
+    print("      subfolder: %s" % subfolder)
+    print("         branch: %s" % branch)
+    print("        cleanup: %s" % cleanup)
+    print("     file types: %s" % file_types)
+    print("      print all: %s" % print_all)
+    print(" url whitetlist: %s" % white_listed_urls)
+    print("   url patterns: %s" % white_listed_patterns)
+    print("  file patterns: %s" % white_listed_files)
+    print("     force pass: %s" % force_pass)
+    print("    retry count: %s" % retry_count)
+    print("        timeout: %s" % timeout)
 
     # If a custom base path is provided, clone and use it
     if git_path not in ["", None]:
@@ -154,11 +160,17 @@ if __name__ == "__main__":
         sys.exit("Cannot find %s to check" % base_path)
 
     # get all file paths
-    file_paths = fileproc.get_file_paths(base_path, file_types)
+    file_paths = fileproc.get_file_paths(base_path=base_path,
+                                         file_types=file_types,
+                                         white_listed_files=white_listed_files)
 
     # check repo urls
-    check_results = check_repo(file_paths, print_all, white_listed_urls,
-                               white_listed_patterns, retry_count, timeout)
+    check_results = check_repo(file_paths=file_paths,
+                               print_all=print_all,
+                               white_listed_urls=white_listed_urls,
+                               white_listed_patterns=white_listed_patterns,
+                               retry_count=retry_count,
+                               timeout=timeout)
 
     # delete repo when done, if requested
     if cleanup == "true":
@@ -166,12 +178,13 @@ if __name__ == "__main__":
 
     # exit
     if len(check_results) == 0:
-        print("Done. No links were collected.")
+        print("\n\nDone. No links were collected.")
         sys.exit(0)
 
     elif force_pass == "false" and len(check_results[1]) > 0 :
-        print("Done. The following URLS did not pass:")
-        print("\x1b[31m" + "\n".join(check_results[1]) + "\x1b[0m")
+        print("\n\nDone. The following URLS did not pass:")
+        for failed_url in check_results[1]:
+            print("\x1b[31m" + failed_url + "\x1b[0m")
         sys.exit(1)
 
     else :

--- a/core/urlproc.py
+++ b/core/urlproc.py
@@ -7,6 +7,19 @@ import requests
 from core import urlmarker
 
 
+def remove_empty(file_list):
+    """
+    Given a file list, return only those that aren't empty string or None.
+
+    Args:
+        file_list (list): a list of files to remove None or empty string from.
+
+    Returns:
+        list of (non None or empty string) contents.
+    """
+    return [x for x in file_list if x not in ["", None]]
+
+
 def record_response(url, response, check_results):
     """
     record response status of an input url. This function is run after success,
@@ -38,6 +51,9 @@ def check_response_status_code(url, response):
     Args:
         url          (str) : url text.
         response    (list) : request response from the url request.
+
+    Returns:
+        boolean to indicate success (True) or fail (False).
     """
     # Case 1: response is None indicating triggered error
     if not response:
@@ -56,6 +72,9 @@ def check_response_status_code(url, response):
 
 def get_user_agent():
     """Return a randomly chosen user agent for requests
+
+    Returns:
+        user agent string to include with User-Agent.
     """
     agents = [
         ('Mozilla/5.0 (X11; Linux x86_64) '
@@ -132,9 +151,8 @@ def check_urls(file, urls, check_results, retry_count=1, timeout=5):
             except requests.exceptions.Timeout as e:
                 print(e)
 
-            except requests.exceptions.ConnectionError:
-                rcount-=1
-                continue
+            except requests.exceptions.ConnectionError as e:
+                print(e)
 
             except Exception as e:
                 print(e)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,7 +6,7 @@ import pytest
 import subprocess
 import configparser
 from core.fileproc import get_file_paths
-from check import clone_repo, del_repo, check_repo
+from check import clone_repo, del_repo, check_repo, get_branch
 
 
 @pytest.mark.parametrize('git_path', ["https://github.com/SuperKogito/SuperKogito.github.io"])
@@ -24,6 +24,32 @@ def test_clone_and_del_repo(git_path):
 
     # delete should have return code of 0 (success)
     if not del_repo(base_path) == 0:
+        raise AssertionError
+
+
+def test_get_branch():
+    """
+    test getting branch from environment or default
+    """
+    # Unset defaults to master
+    branch = get_branch()
+    if branch != "master":
+        raise AssertionError
+
+    # Set both GitHub input variable and ref (ref takes priority)
+    for pair in [["INPUT_BRANCH", "devel"], ["GITHUB_REF", "refs/heads/branchy"]]:
+        os.environ[pair[0]] = pair[1]
+        os.putenv(pair[0], pair[1])
+
+    # Second preference should be for INPUT_BRANCH
+    branch = get_branch()
+    if branch != "devel":
+        raise AssertionError
+
+    del os.environ['INPUT_BRANCH']
+    os.unsetenv("INPUT_BRANCH")
+    branch = get_branch()
+    if branch != "branchy":
         raise AssertionError
 
 

--- a/tests/test_fileproc.py
+++ b/tests/test_fileproc.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+import os
 import pytest
-from core.fileproc import check_file_type, get_file_paths, collect_links_from_file
+from core.fileproc import check_file_type, get_file_paths, collect_links_from_file, include_file
 
 
 @pytest.mark.parametrize('file_path', ["tests/test_files/sample_test_file.md",
@@ -20,6 +21,27 @@ def test_check_file_type(file_path, file_types):
     if output:
         raise AssertionError
 
+
+@pytest.mark.parametrize('file_path', ["tests/test_files/sample_test_file.md",
+                                       "tests/test_files/sample_test_file.py"])
+@pytest.mark.parametrize('white_list_patterns', [["[.py]"], ["[.md]"], ["tests/test_file"]])
+def test_include_files(file_path, white_list_patterns):
+    """
+    test if a file should be included based on patterns (using extension for test)
+    """
+    _, extension = os.path.splitext(file_path)
+    expected = not extension in file_path
+    result = include_file(file_path, white_list_patterns)
+
+    # No files should be included for a global path pattern
+    if "tests/test_file" in white_list_patterns:
+        if result:
+            raise AssertionError
+
+    # Otherwise, the patterns should honor extension
+    else:
+        if result != expected:
+            raise AssertionError
 
 @pytest.mark.parametrize('base_path', ["tests/test_files"])
 @pytest.mark.parametrize('file_types', [[".md", ".py"]])

--- a/tests/test_urlproc.py
+++ b/tests/test_urlproc.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 from core.fileproc import collect_links_from_file
-from core.urlproc import check_response_status_code, check_urls
+from core.urlproc import check_response_status_code, check_urls, remove_empty
 
 
 @pytest.mark.parametrize('file', ["tests/test_files/sample_test_file.md",
@@ -13,3 +13,12 @@ def test_check_urls(file):
     """
     urls = collect_links_from_file(file)
     check_urls(file, urls, check_results=[[],[]])
+
+
+def test_remove_empty():
+    """
+    test that empty urls are removed
+    """
+    urls = ["notempty", "notempty", "", None]
+    if len(remove_empty(urls)) != 2:
+        raise AssertionError


### PR DESCRIPTION
This commit will address several issues, including:
1. Adding extra space at the end of the test to print failed urls, ensuring red closes #28 
2. Adding variable white_listed_files to handle file paths or patterns to skip, closes #27 
3. Ensuring that escaped newlines are removed from trailing urls fixes #26

Signed-off-by: vsoch <vsochat@stanford.edu>