### PR TITLE
adding small examples folder, can be extended on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 A GitHub action to collect and check URLs in a project (code and documentation).
 The action aims at detecting and reporting broken links.
 
-## Code documentation
-
-A detailed documentation of the code is available under [urls-checker.readthedocs.io](https://urls-checker.readthedocs.io/en/latest/)
-
 ## How to use it?
+
+A set of examples are included in the [examples](examples) folder. A few detailed 
+examples are also included below.
 
 ### Example with Checkout
 
@@ -30,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: urls-checker
-      uses: urlstechie/urlchecker-action@0.1.5
+      uses: urlstechie/urlchecker-action@0.1.7
       with:
         # A subfolder or path to navigate to in the present or cloned repository
         subfolder: docs
@@ -76,7 +75,7 @@ jobs:
 
     steps:
     - name: URLs-checker
-      uses: urlstechie/urlchecker-action@0.1.5
+      uses: urlstechie/urlchecker-action@0.1.7
       with:
         # A project to clone. If not provided, assumes already cloned in the present working directory.
         git_path: https://github.com/urlstechie/URLs-checker-test-repo
@@ -138,3 +137,13 @@ jobs:
 
 - Using version =< 0.1.4
 <img src="demo.gif"/>
+
+## Support
+
+Do you have a question or an issue? Please [open an issue](https://github.com/urlstechie/urlchecker-action/issues) and we can help!
+The following communities are using the url checker! You can look here for examples
+or inspiration. If you want to add your community, please let us know with an issue.
+
+- [awesome-rseng](https://github.com/rseng/awesome-rseng)
+- [buildtest](https://github.com/HPC-buildtest/buildtest-framework)
+- [The United States Research Software Engineer Assocation](https://github.com/USRSE/usrse.github.io)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+The following examples are added for your convenience. Each of these files
+would be added to a .github/workflows folder to be run on some [github event](https://help.github.com/en/actions/reference/events-that-trigger-workflows).
+
+## General
+
+- [GitHub Checkout](urlchecker-checkout.yml): the most likely case of usage for this action is checking out the repository that the action is running for, meaning we use the active branch for the check.
+- [GitHub Clone](urlchecker-clone.yml): while it's more a niche use case, you might want to clone one or more repos to check for an action run.
+
+## White Listing
+
+- [urlchecker-whitelist-files.yml](urlchecker-whitelist-files.yml): in this example, we have a repository where we want to check only a README.md file at the root, and importantly, skip over an entire subfolder that serves a rendered site at docs. We want to run the check whenever someone opens a pull request.
+
+If you'd like to see an example added, please [open an issue](https://github.com/urlstechie/urlchecker-action/issues).

--- a/examples/urlchecker-checkout.yml
+++ b/examples/urlchecker-checkout.yml
@@ -1,0 +1,36 @@
+name: Check URLs
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: urls-checker
+      uses: urlstechie/urlchecker-action@0.1.7
+      with:
+        # A subfolder or path to navigate to in the present or cloned repository
+        subfolder: docs
+
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.py,.rst
+
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 5
+
+        # How many times to retry a failed request (each is logged, defaults to 1)
+        retry_count: 3
+
+        # A comma separated links to exclude during URL checks
+        white_listed_urls: https://github.com/SuperKogito/URLs-checker/issues/1,https://github.com/SuperKogito/URLs-checker/issues/2
+
+        # A comma separated patterns to exclude during URL checks
+        white_listed_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
+
+        # choose if the force pass or not
+        force_pass : true

--- a/examples/urlchecker-clone.yml
+++ b/examples/urlchecker-clone.yml
@@ -1,0 +1,47 @@
+name: Check URLs
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: URLs-checker
+      uses: urlstechie/urlchecker-action@0.1.7
+      with:
+        # A project to clone. If not provided, assumes already cloned in the present working directory.
+        git_path: https://github.com/urlstechie/URLs-checker-test-repo
+
+        # If a git_path is defined to clone, clone this branch (defaults to master)
+        branch: devel
+
+        # A subfolder or path to navigate to in the present or cloned repository
+        subfolder: docs
+
+        # Delete the cloned repository after running URLchecked (default is false)
+        cleanup: true
+
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.py,.rst
+
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 5
+
+        # How many times to retry a failed request (each is logged, defaults to 1)
+        retry_count: 3
+
+        # A comma separated links to exclude during URL checks
+        white_listed_urls: https://github.com/SuperKogito/URLs-checker/issues/1,https://github.com/SuperKogito/URLs-checker/issues/2
+
+        # A comma separated patterns to exclude during URL checks
+        white_listed_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
+
+        # A comma separated list of file patterns (direct paths work as well) to exclude
+        white_listed_files: README.md,/github/workspace/_config.yml
+
+        # choose if the force pass or not
+        force_pass : true

--- a/examples/urlchecker-whitelist-files.yml
+++ b/examples/urlchecker-whitelist-files.yml
@@ -1,0 +1,14 @@
+name: URLChecker
+on: [pull_request]
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+    - name: Test GitHub Action
+      uses: urlstechie/urlchecker-action@0.1.7
+      with: 
+        file_types: .md
+        white_listed_files: docs


### PR DESCRIPTION
This will add a small examples folder, along with removing the docs link (to read the docs) which is no longer hooked up. I also added a small listing of repos using the action, in case people want to add theirs or just see recipes out in the wild.

Signed-off-by: vsoch <vsochat@stanford.edu>