### PR TITLE
adding save argument to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ jobs:
 | `file_types`                | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
 | `print_all`                 | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
 | `retry_count`               | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |
+| `save`                      | <span style="color:green"> optional </span>  | A path to a csv file to save results to                          |
 | `timeout`                   | <span style="color:green"> optional </span>  | The timeout to provide to requests to wait for a response.       |
 | `white_listed_urls`         | <span style="color:green"> optional </span>  | A comma separated links to exclude during URL checks.            |
 | `white_listed_patterns`     | <span style="color:green"> optional </span>  | A comma separated patterns to exclude during URL checks.         |

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: 1
 
+  save:
+    description: "A csv file path to save the results to."
+    required: false
+    default: ""
+
   timeout:
     description: "The timeout (seconds) to provide to requests to wait for a response."
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,11 @@ if [ ! -z "${INPUT_TIMEOUT}" ]; then
     COMMAND="${COMMAND} --timeout ${INPUT_TIMEOUT}"
 fi
 
+# save (optional)
+if [ ! -z "${INPUT_SAVE}" ]; then
+    COMMAND="${COMMAND} --save ${INPUT_SAVE}"
+fi
+
 # force pass (optional)
 if [ "${INPUT_FORCE_PASS}" == "true" ]; then
     echo "Force pass requested."


### PR DESCRIPTION
This PR will expose the `--save` argument for the action. This will need to be tested with urlchecker-python PR #14 is merged and the quay.io container is built that will allow for the --save argument.

https://github.com/urlstechie/urlchecker-python/pull/14

Signed-off-by: vsoch <vsochat@stanford.edu>