### PR TITLE
updating action to include --files argument

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
       uses: ./
       with: 
         git_path: https://github.com/urlstechie/urlchecker-test-repo
+        subfolder: test_action
         file_types: .md,.py,.rst
         timeout: 5
         retry_count: 3

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ jobs:
 | `cleanup`                   | <span style="color:green"> optional </span>  | If we do a clone, delete the cloned folder after (false)         |
 | `subfolder`                 | <span style="color:green"> optional </span>  | A subfolder to navigate to in the repository to check            |
 | `file_types`                | <span style="color:green"> optional </span>  | A comma-separated list of file types to cover in the URLs checks.|
+| `include_files`             | <span style="color:green"> optional </span>  | A comma-separated list of exact files to check.                  |
 | `print_all`                 | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.       |
 | `retry_count`               | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1    |
 | `save`                      | <span style="color:green"> optional </span>  | A path to a csv file to save results to                          |

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: false
 
+  include_files:
+    description: "A comma seperated list of paths or patterns to include."
+    required: false
+    default: ""
+
   file_types:
     description: "A comma-separated list of file types to cover in the URL checks"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,11 @@ if [ ! -z "${INPUT_TIMEOUT}" ]; then
     COMMAND="${COMMAND} --timeout ${INPUT_TIMEOUT}"
 fi
 
+# files (optional)
+if [ ! -z "${INPUT_INCLUDE_FILES}" ]; then
+    COMMAND="${COMMAND} --files ${INPUT_INCLUDE_FILES}"
+fi
+
 # save (optional)
 if [ ! -z "${INPUT_SAVE}" ]; then
     COMMAND="${COMMAND} --save ${INPUT_SAVE}"

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,4 +12,8 @@ would be added to a .github/workflows folder to be run on some [github event](ht
 
 - [urlchecker-whitelist-files.yml](urlchecker-whitelist-files.yml): in this example, we have a repository where we want to check only a README.md file at the root, and importantly, skip over an entire subfolder that serves a rendered site at docs. We want to run the check whenever someone opens a pull request.
 
+## Include Files
+
+- [urlchecker-include-files.yml](urlchecker-include-files.yml): as an alternative to white listing files or patterns, you can specify an explicit file path or pattern to check. This is useful if you want to set some comma separated listing of files or patterns in another step, and then set for the action here.
+
 If you'd like to see an example added, please [open an issue](https://github.com/urlstechie/urlchecker-action/issues).

--- a/examples/urlchecker-include-files.yml
+++ b/examples/urlchecker-include-files.yml
@@ -1,0 +1,14 @@
+name: URLChecker
+on: [pull_request]
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v2
+    - name: Test GitHub Action
+      uses: urlstechie/urlchecker-action@0.1.9
+      with: 
+        file_types: .md
+        include_files: README.md


### PR DESCRIPTION
This pull request will add the `--files` flag, an argument exposed as `include_files` to allow the user to specify one or more file paths or patterns to include.

Signed-off-by: vsoch <vsochat@stanford.edu>