### PR TITLE
fixing bug with cleanup flag, should check for true to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: urls-checker
-      uses: urlstechie/urlchecker-action@0.1.9
+      uses: urlstechie/urlchecker-action@0.2.0
       with:
         # A subfolder or path to navigate to in the present or cloned repository
         subfolder: docs
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: URLs-checker
-      uses: urlstechie/urlchecker-action@0.1.9
+      uses: urlstechie/urlchecker-action@0.2.0
       with:
         # A project to clone. If not provided, assumes already cloned in the present working directory.
         git_path: https://github.com/urlstechie/URLs-checker-test-repo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ if [ ! -z "${INPUT_BRANCH}" ]; then
 fi
 
 # cleanup is optional (boolean)
-if [ ! -z "${INPUT_CLEANUP}" ]; then
+if [ "${INPUT_CLEANUP}" == "true" ]; then
     COMMAND="${COMMAND} --cleanup"
 fi
 

--- a/examples/urlchecker-save-artifact.yml
+++ b/examples/urlchecker-save-artifact.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: urls-checker
-      uses: urlstechie/urlchecker-action@0.1.9
+      uses: urlstechie/urlchecker-action@0.2.0
       with:
         # A subfolder or path to navigate to in the present or cloned repository
         subfolder: docs


### PR DESCRIPTION
This PR fixes a bug introduced a few releases back with the `--cleaup` flag - it needs to be checked to be "true" and not that it's set at all.

Signed-off-by: vsoch <vsochat@stanford.edu>