### PR TITLE
Add tests trigger on action release

### DIFF
--- a/.github/workflows/tests_trigger.yml
+++ b/.github/workflows/tests_trigger.yml
@@ -1,5 +1,12 @@
+name: Trigger tests 
 on:
   release:
     types: [created, published]
-      run: |
-        curl -XPOST -u "${{ secrets.SuperKogito}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/urlstechie/urlchecker-test-repo/dispatches --data '{"event_type": "build_application"}'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: send trigger
+      run: curl -XPOST -u "${{secrets.SuperKogito}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/urlstechie/urlchecker-test-repo/dispatches --data '{"event_type": "build_application"}'

--- a/.github/workflows/tests_trigger.yml
+++ b/.github/workflows/tests_trigger.yml
@@ -1,0 +1,5 @@
+on:
+  release:
+    types: [created, published]
+      run: |
+        curl -XPOST -u "${{ secrets.SuperKogito}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/urlstechie/urlchecker-test-repo/dispatches --data '{"event_type": "build_application"}'


### PR DESCRIPTION
- Add trigger to launch workflow in [urlchecker-test-repo](https://github.com/urlstechie/urlchecker-test-repo).

- Aims to fix https://github.com/urlstechie/urlchecker-action/issues/43.

- This workflow is based on the following:
  - https://github.community/t5/GitHub-Actions/Github-Action-trigger-on-release-not-working-if-releases-was/td-p/34559
  - https://twitter.com/GeertvdC/status/1183837353493893122
  - https://github.community/t5/GitHub-Actions/Triggering-by-other-repository/m-p/30668 