### PR TITLE
Preparing updates to container base with debian buster and certifi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM quay.io/urlstechie/urlchecker:0.0.22
+RUN pip install --upgrade certifi
 COPY entrypoint.sh /entrypoint.sh
 WORKDIR /github/workspace
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM quay.io/urlstechie/urlchecker:0.0.22
-RUN pip install --upgrade certifi
+FROM quay.io/urlstechie/urlchecker:0.0.23
 COPY entrypoint.sh /entrypoint.sh
 WORKDIR /github/workspace
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
To follow up with https://github.com/urlstechie/urlchecker-action/issues/79, this better shows the changes on the branch (one line now that we have a base image with certifi and debian buster).