### PR TITLE
Feature: Add SARIF Support for URL Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ jobs:
 
         # choose if the force pass or not
         force_pass: true
+
+        # save the results to a file
+        save: results.csv
+
+        # The results format saved to a file. Supported: 'csv' or 'sarif'. Default is csv
+        format: csv 
 ```
 ## Inputs
 
@@ -138,7 +144,8 @@ jobs:
 | `print_all`                 | <span style="color:green"> optional </span>  | Choose whether to include file with no URLs in the prints.                     |
 | `verbose`                   | <span style="color:green"> optional </span>  | Choose whether to print a more verbose end summary with files and broken URLs  |
 | `retry_count`               | <span style="color:green"> optional </span>  | If a request fails, retry this number of times. Defaults to 1                  |
-| `save`                      | <span style="color:green"> optional </span>  | A path to a csv file to save results to                                        |
+| `save`                      | <span style="color:green"> optional </span>  | A path to a file to save results to                                        |
+| `format`                      | <span style="color:green"> optional </span>  | The results format saved to a file. Supported: 'csv' or 'sarif'. Default is csv                                        |
 | `timeout`                   | <span style="color:green"> optional </span>  | The timeout to provide to requests to wait for a response.                     |
 | `exclude_urls`              | <span style="color:green"> optional </span>  | A comma separated list of links.                                               |
 | `exclude_patterns`          | <span style="color:green"> optional </span>  | A comma separated list of patterns.                                            |

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,12 @@ inputs:
     default: 1
 
   save:
-    description: "A csv file path to save the results to."
+    description: "A file path to save the results to."
+    required: false
+    default: ""
+  
+  format:
+    description: "The results format saved to a file. Supported: 'csv' or 'sarif'. Default is csv."
     required: false
     default: ""
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,11 @@ if [ ! -z "${INPUT_SAVE}" ]; then
     COMMAND="${COMMAND} --save ${INPUT_SAVE}"
 fi
 
+# format (optional)
+if [ ! -z "${INPUT_FORMAT}" ]; then
+    COMMAND="${COMMAND} --format ${INPUT_FORMAT}"
+fi
+
 # force pass (optional)
 if [ "${INPUT_FORCE_PASS}" == "true" ]; then
     echo "Force pass requested."

--- a/examples/urlchecker-save-artifact-sarif.yml
+++ b/examples/urlchecker-save-artifact-sarif.yml
@@ -1,0 +1,49 @@
+name: Check URLs SARIF format
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: urls-checker
+      uses: urlstechie/urlchecker-action@master
+      with:
+        # A subfolder or path to navigate to in the present or cloned repository
+        subfolder: docs
+
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.py,.rst
+
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+
+        # The timeout seconds to provide to requests, defaults to 5 seconds
+        timeout: 5
+
+        # How many times to retry a failed request (each is logged, defaults to 1)
+        retry_count: 3
+
+        # A comma separated links to exclude during URL checks
+        exclude_urls: https://github.com/SuperKogito/URLs-checker/issues/1,https://github.com/SuperKogito/URLs-checker/issues/2
+
+        # A comma separated patterns to exclude during URL checks
+        exclude_patterns: https://github.com/SuperKogito/Voice-based-gender-recognition/issues
+
+        # choose if the force pass or not
+        force_pass : true
+
+        # Save to results.sarif
+        save: results.sarif
+
+        # Save SARIF format
+        format: sarif
+    
+    - name: Upload check results
+      if: always()
+      uses: actions/upload-artifact@v2-preview
+      with:
+        name: urlchecker-results
+        path: results.sarif


### PR DESCRIPTION
### Description

This PR adds SARIF support to the `urlchecker-action`. This enhancement aims to improve the integration of URL-checking results with GitHub Actions, providing more detailed and actionable reports.

### How to Use

To enable SARIF output in the GitHub Action workflow, update your workflow file to include the `--save results.sarif` option:

```yaml
- name: URL Checker
  uses: urlstechie/urlchecker-action@master
  with:
    save: results.sarif
    format: sarif
```

### Linked PR

This PR is linked to [urlchecker-python PR #91](https://github.com/urlstechie/urlchecker-python/pull/91), which introduces SARIF support in the core `urlchecker-python` library. The combination of these PRs ensures that URL-checking results can be saved in SARIF format, enhancing static analysis and reporting in CI/CD workflows.